### PR TITLE
Version bump on nispor crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ name = "mzc"
 path = "src/main.rs"
 
 [dependencies]
-nispor = "1.2.10"
+nispor = "1.2.12"
 tokio = "1.25.0"
 mozim = "0.2.2"
 clap = { version = "4.1.4", features = ["cargo"] }


### PR DESCRIPTION
Fixes a Fails To Build From Source being caused
by Rust-netlink Bundle release 2023-07-10
( https://github.com/orgs/rust-netlink/discussions/6 )